### PR TITLE
[Chore] application.yaml 운영 환경 별 프로필 그룹 설정

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,16 +2,14 @@ spring:
   application:
     name: member-service
   profiles:
-    active: local
-    include:
-      - redis
-      - eureka
-      - datasource
-      - security
-      - actuator
+    group:
+      "local": "local, default-datasource, default-redis, security, eureka, openfeign, actuator"
+      "docker": "docker, default-datasource, default-redis, security, eureka, openfeign, actuator"
+      "prod": "prod, prod-datasource, prod-data-redis, security, eureka, openfeign, actuator"
+    active: "local"
 
   config:
     import: optional:configserver:${CONFIG_SERVER_URL:http://localhost:8888}
-
-logback:
-  log-path: ./logs
+#
+#logback:
+#  log-path: ./logs


### PR DESCRIPTION
## 🛠️ Issue Number
### closes #17 

📌 **작업 내용 및 특이사항**
## 기존 구조

```yaml
spring:
  application:
    name: member-service
  profiles:
    active: "local"
    include:
      - redis
      - eureka
      - datasource
      - security
      - actuator

  config:
    import: optional:configserver:${CONFIG_SERVER_URL:http://localhost:8888}
```

## 변경된 구조(Spring 2.4 이후 group 방식 적용)

```yaml
spring:
  application:
    name: member-service
  profiles:
    group:
      "local": "local, default-datasource, default-redis, security, eureka, openfeign, actuator"
      "docker": "docker, default-datasource, default-redis, security, eureka, openfeign, actuator"
      "prod": "prod, prod-datasource, prod-data-redis, security, eureka, openfeign, actuator"
    active: "local"

  config:
    import: optional:configserver:${CONFIG_SERVER_URL:http://localhost:8888}
```


📚 **참고사항**
